### PR TITLE
Unstable - Merging changes to support a securely stored password and salt for encryption

### DIFF
--- a/SalesforceSDK/NoteSync/NoteSync.Shared/App.xaml.cs
+++ b/SalesforceSDK/NoteSync/NoteSync.Shared/App.xaml.cs
@@ -41,11 +41,7 @@ namespace NoteSync.Shared
         /// <returns></returns>
         protected override SalesforceConfig InitializeConfig()
         {
-            var settings = new EncryptionSettings(new HmacSHA256KeyGenerator())
-            {
-                Password = "65775192-a513-48c6-820d-0b2ed441719a",
-                Salt = "2a9eefe9-be68-418a-a2ed-29df688e9c5f"
-            };
+            var settings = new EncryptionSettings(new HmacSHA256KeyGenerator());
             Encryptor.init(settings);
             var config = SalesforceConfig.RetrieveConfig<Config>();
             if (config == null)

--- a/SalesforceSDK/NoteSync/NoteSync.Shared/ViewModel/NoteObject.cs
+++ b/SalesforceSDK/NoteSync/NoteSync.Shared/ViewModel/NoteObject.cs
@@ -27,7 +27,6 @@
 
 using System;
 using System.ComponentModel;
-using System.ComponentModel.DataAnnotations;
 using System.Runtime.CompilerServices;
 using System.Text;
 using Newtonsoft.Json.Linq;

--- a/SalesforceSDK/Salesforce.SDK.Core/Source/Auth/AuthStorageHelper.cs
+++ b/SalesforceSDK/Salesforce.SDK.Core/Source/Auth/AuthStorageHelper.cs
@@ -429,7 +429,7 @@ namespace Salesforce.SDK.Auth
             var encrpytionSettings = new PasswordCredential(PasswordVaultSecuredData, PasswordVaultEncryptionSettings,
                 JsonConvert.SerializeObject(encryptionSettingsObj));
             _vault.Add(encrpytionSettings);
-            SalesforceApplication.SendToCustomLogger("AuthStorageHelper.PersistEncryptionSettings - encryption settings added to vault",
+            PlatformAdapter.SendToCustomLogger("AuthStorageHelper.PersistEncryptionSettings - encryption settings added to vault",
                 LoggingLevel.Verbose);
         }
 
@@ -444,7 +444,7 @@ namespace Salesforce.SDK.Auth
                 if (String.IsNullOrWhiteSpace(encrpytionSettings.Password))
                 {
                     // Failed to deserialize the data, we should clear it out and start over.
-                    SalesforceApplication.SendToCustomLogger(
+                    PlatformAdapter.SendToCustomLogger(
                         "AuthStorageHelper.TryRetrieveEncryptionSettings - Encryption Settings values are corrupt. Assuming bad state and clearing the vault completely",
                         LoggingLevel.Verbose);
                     _vault.Remove(encrpytionSettings);
@@ -458,7 +458,7 @@ namespace Salesforce.SDK.Auth
                         var encrpytionSettingsObj = JsonConvert.DeserializeObject<dynamic>(encrpytionSettings.Password);
                         password = encrpytionSettingsObj.Password;
                         salt = encrpytionSettingsObj.Salt;
-                        SalesforceApplication.SendToCustomLogger(
+                        PlatformAdapter.SendToCustomLogger(
                         "AuthStorageHelper.TryRetrieveEncryptionSettings - Encryption Settings have been retrieved successfully.",
                         LoggingLevel.Verbose);
                         return true;
@@ -466,11 +466,11 @@ namespace Salesforce.SDK.Auth
                     catch (Exception ex)
                     {
                         // Failed to deserialize the data, we should clear it out and start over.
-                        SalesforceApplication.SendToCustomLogger(
+                        PlatformAdapter.SendToCustomLogger(
                             "AuthStorageHelper.TryRetrieveEncryptionSettings - Encryption Settings values can't be deserialized. Assuming bad state and clearing the vault completely",
                             LoggingLevel.Verbose);
 
-                        SalesforceApplication.SendToCustomLogger(ex, LoggingLevel.Warning);
+                        PlatformAdapter.SendToCustomLogger(ex, LoggingLevel.Warning);
                         
                         _vault.Remove(encrpytionSettings);
                         DeletePersistedCredentials();
@@ -486,14 +486,14 @@ namespace Salesforce.SDK.Auth
                 // If either account or pincode are stored, but the Encryption Settings values can't be retrieved, then we should assume we are in a bad state and clear the vault.
                 if (account != null || pincode != null)
                 {
-                    SalesforceApplication.SendToCustomLogger(
+                    PlatformAdapter.SendToCustomLogger(
                         "AuthStorageHelper.TryRetrieveEncryptionSettings - Encryption Settings values can't be retrieved from vault. Assuming bad state and clearing the vault completely",
                         LoggingLevel.Verbose);
                     DeletePersistedCredentials();
                     DeletePincode();
                 }
             }
-            SalesforceApplication.SendToCustomLogger(
+            PlatformAdapter.SendToCustomLogger(
                         "AuthStorageHelper.TryRetrieveEncryptionSettings - Encryption Settings have not yet been saved.",
                         LoggingLevel.Verbose);
             return false;
@@ -504,7 +504,7 @@ namespace Salesforce.SDK.Auth
             PasswordCredential encryptionSettings = SafeRetrieveUser(PasswordVaultSecuredData, PasswordVaultEncryptionSettings);
             if (encryptionSettings != null)
             {
-                SalesforceApplication.SendToCustomLogger(
+                PlatformAdapter.SendToCustomLogger(
                     "AuthStorageHelper.DeleteEncryptionSettings - removed encryption settings from vault",
                     LoggingLevel.Verbose);
                 _vault.Remove(encryptionSettings);

--- a/SalesforceSDK/Salesforce.SDK.Core/Source/Auth/AuthStorageHelper.cs
+++ b/SalesforceSDK/Salesforce.SDK.Core/Source/Auth/AuthStorageHelper.cs
@@ -48,6 +48,7 @@ namespace Salesforce.SDK.Auth
         private const string PasswordVaultCurrentAccount = "Salesforce Account";
         private const string PasswordVaultSecuredData = "Salesforce Secure";
         private const string PasswordVaultPincode = "Salesforce Pincode";
+        private const string PasswordVaultEncryptionSettings = "Salesforce Encryption Settings";
         private const string InstallationStatusKey = "InstallationStatus";
 
         private static readonly Lazy<AuthStorageHelper> Auth = new Lazy<AuthStorageHelper>(() => new AuthStorageHelper());
@@ -417,6 +418,95 @@ namespace Salesforce.SDK.Auth
             if (_persistedData.Values.ContainsKey(key))
             {
                 _persistedData.Values.Remove(key);
+            }
+        }
+
+        internal void PersistEncryptionSettings(string password, string salt, string nonce = null)
+        {
+            DeleteEncryptionSettings();
+            var encryptionSettingsObj = new { Password = password, Salt = salt };
+            var encrpytionSettings = new PasswordCredential(PasswordVaultSecuredData, PasswordVaultEncryptionSettings,
+                JsonConvert.SerializeObject(encryptionSettingsObj));
+            _vault.Add(encrpytionSettings);
+            SalesforceApplication.SendToCustomLogger("AuthStorageHelper.PersistEncryptionSettings - encryption settings added to vault",
+                LoggingLevel.Verbose);
+        }
+
+        internal bool TryRetrieveEncryptionSettings(out string password, out string salt, string nonce = null)
+        {
+            password = null;
+            salt = null;
+            PasswordCredential creds = SafeRetrieveResource(PasswordVaultSecuredData).FirstOrDefault();
+            if (creds != null)
+            {
+                PasswordCredential encrpytionSettings = _vault.Retrieve(PasswordVaultSecuredData, PasswordVaultEncryptionSettings);
+                if (String.IsNullOrWhiteSpace(encrpytionSettings.Password))
+                {
+                    // Failed to deserialize the data, we should clear it out and start over.
+                    SalesforceApplication.SendToCustomLogger(
+                        "AuthStorageHelper.TryRetrieveEncryptionSettings - Encryption Settings values are corrupt. Assuming bad state and clearing the vault completely",
+                        LoggingLevel.Verbose);
+                    _vault.Remove(encrpytionSettings);
+                    DeletePersistedCredentials();
+                    DeletePincode();
+                }
+                else
+                {
+                    try
+                    {
+                        var encrpytionSettingsObj = JsonConvert.DeserializeObject<dynamic>(encrpytionSettings.Password);
+                        password = encrpytionSettingsObj.Password;
+                        salt = encrpytionSettingsObj.Salt;
+                        SalesforceApplication.SendToCustomLogger(
+                        "AuthStorageHelper.TryRetrieveEncryptionSettings - Encryption Settings have been retrieved successfully.",
+                        LoggingLevel.Verbose);
+                        return true;
+                    }
+                    catch (Exception ex)
+                    {
+                        // Failed to deserialize the data, we should clear it out and start over.
+                        SalesforceApplication.SendToCustomLogger(
+                            "AuthStorageHelper.TryRetrieveEncryptionSettings - Encryption Settings values can't be deserialized. Assuming bad state and clearing the vault completely",
+                            LoggingLevel.Verbose);
+
+                        SalesforceApplication.SendToCustomLogger(ex, LoggingLevel.Warning);
+                        
+                        _vault.Remove(encrpytionSettings);
+                        DeletePersistedCredentials();
+                        DeletePincode();
+                    }
+                }
+
+            }
+            else
+            {
+                var account = RetrieveCurrentAccount();
+                var pincode = RetrievePincode();
+                // If either account or pincode are stored, but the Encryption Settings values can't be retrieved, then we should assume we are in a bad state and clear the vault.
+                if (account != null || pincode != null)
+                {
+                    SalesforceApplication.SendToCustomLogger(
+                        "AuthStorageHelper.TryRetrieveEncryptionSettings - Encryption Settings values can't be retrieved from vault. Assuming bad state and clearing the vault completely",
+                        LoggingLevel.Verbose);
+                    DeletePersistedCredentials();
+                    DeletePincode();
+                }
+            }
+            SalesforceApplication.SendToCustomLogger(
+                        "AuthStorageHelper.TryRetrieveEncryptionSettings - Encryption Settings have not yet been saved.",
+                        LoggingLevel.Verbose);
+            return false;
+        }
+
+        internal void DeleteEncryptionSettings()
+        {
+            PasswordCredential encryptionSettings = SafeRetrieveUser(PasswordVaultSecuredData, PasswordVaultEncryptionSettings);
+            if (encryptionSettings != null)
+            {
+                SalesforceApplication.SendToCustomLogger(
+                    "AuthStorageHelper.DeleteEncryptionSettings - removed encryption settings from vault",
+                    LoggingLevel.Verbose);
+                _vault.Remove(encryptionSettings);
             }
         }
     }

--- a/SalesforceSDK/Salesforce.SDK.Core/Source/Auth/AuthStorageHelper.cs
+++ b/SalesforceSDK/Salesforce.SDK.Core/Source/Auth/AuthStorageHelper.cs
@@ -422,7 +422,7 @@ namespace Salesforce.SDK.Auth
             }
         }
 
-        internal void PersistEncryptionSettings(string password, string salt, string nonce = null)
+        internal void PersistEncryptionSettings(string password, string salt)
         {
             DeleteEncryptionSettings();
             var encryptionSettingsObj = new { Password = password, Salt = salt };
@@ -433,7 +433,7 @@ namespace Salesforce.SDK.Auth
                 LoggingLevel.Verbose);
         }
 
-        internal bool TryRetrieveEncryptionSettings(out string password, out string salt, string nonce = null)
+        internal bool TryRetrieveEncryptionSettings(out string password, out string salt)
         {
             password = null;
             salt = null;
@@ -446,7 +446,7 @@ namespace Salesforce.SDK.Auth
                     // Failed to deserialize the data, we should clear it out and start over.
                     PlatformAdapter.SendToCustomLogger(
                         "AuthStorageHelper.TryRetrieveEncryptionSettings - Encryption Settings values are corrupt. Assuming bad state and clearing the vault completely",
-                        LoggingLevel.Verbose);
+                        LoggingLevel.Warning);
                     _vault.Remove(encrpytionSettings);
                     DeletePersistedCredentials();
                     DeletePincode();
@@ -468,7 +468,7 @@ namespace Salesforce.SDK.Auth
                         // Failed to deserialize the data, we should clear it out and start over.
                         PlatformAdapter.SendToCustomLogger(
                             "AuthStorageHelper.TryRetrieveEncryptionSettings - Encryption Settings values can't be deserialized. Assuming bad state and clearing the vault completely",
-                            LoggingLevel.Verbose);
+                            LoggingLevel.Warning);
 
                         PlatformAdapter.SendToCustomLogger(ex, LoggingLevel.Warning);
                         

--- a/SalesforceSDK/Salesforce.SDK.Core/Source/Security/EncryptionSettings.cs
+++ b/SalesforceSDK/Salesforce.SDK.Core/Source/Security/EncryptionSettings.cs
@@ -40,14 +40,12 @@ namespace Salesforce.SDK.Source.Security
             KeyGenerator = keyGenerator;
         }
 
-        public string Password { get; set; }
-        public string Salt { get; set; }
         public string SymmetricAlgorithm { get; private set; }
         public string KeyDerivationAlgorithm { get; private set; }
 
         public void GenerateKey(out IBuffer keyMaterial, out IBuffer iv, string nonce)
         {
-            KeyGenerator.GenerateKey(Password, Salt, nonce, out keyMaterial, out iv);
+            KeyGenerator.GenerateKey(KeyGenerator.Salt, KeyGenerator.Password, nonce, out keyMaterial, out iv);
         }
     }
 }

--- a/SalesforceSDK/Salesforce.SDK.Core/Source/Security/HmacSHA256KeyGenerator.cs
+++ b/SalesforceSDK/Salesforce.SDK.Core/Source/Security/HmacSHA256KeyGenerator.cs
@@ -32,6 +32,7 @@ using Windows.Security.Cryptography;
 using Windows.Security.Cryptography.Core;
 using Windows.Storage.Streams;
 using Windows.System.Profile;
+using Salesforce.SDK.Auth;
 
 namespace Salesforce.SDK.Source.Security
 {
@@ -42,6 +43,39 @@ namespace Salesforce.SDK.Source.Security
     /// </summary>
     public sealed class HmacSHA256KeyGenerator : IKeyGenerator
     {
+        private readonly string _password;
+        public string Password
+        {
+            get
+            {
+                return _password;
+            }
+        }
+
+        private readonly string _salt;
+        public string Salt
+        {
+            get
+            {
+                return _salt;
+            }
+        }
+
+        public HmacSHA256KeyGenerator()
+        {
+            string password;
+            string salt;
+
+            var authStorageHelper = AuthStorageHelper.GetAuthStorageHelper();
+            if (!authStorageHelper.TryRetrieveEncryptionSettings(out password, out salt))
+            {
+                GenerateRandomPasswordAndSalt(out password, out salt);
+                authStorageHelper.PersistEncryptionSettings(password, salt);
+            }
+            _password = password;
+            _salt = salt;
+        }
+
         public void GenerateKey(string password, string salt, string nonce, out IBuffer keyMaterial, out IBuffer iv)
         {
             IBuffer saltBuffer = CryptographicBuffer.ConvertStringToBinary(salt, BinaryStringEncoding.Utf8);
@@ -116,6 +150,12 @@ namespace Salesforce.SDK.Source.Security
                 nonce = "";
             }
             return CryptographicBuffer.ConvertStringToBinary(GetDeviceUniqueId() + nonce, BinaryStringEncoding.Utf8);
+        }
+
+        private void GenerateRandomPasswordAndSalt(out string password, out string salt)
+        {
+            password = Guid.NewGuid().ToString();
+            salt = Guid.NewGuid().ToString();
         }
     }
 }

--- a/SalesforceSDK/Salesforce.SDK.Core/Source/Security/IKeyGenerator.cs
+++ b/SalesforceSDK/Salesforce.SDK.Core/Source/Security/IKeyGenerator.cs
@@ -31,6 +31,15 @@ namespace Salesforce.SDK.Source.Security
 {
     public interface IKeyGenerator
     {
+        string Password
+        {
+            get;
+        }
+
+        string Salt
+        {
+            get;
+        }
         void GenerateKey(string salt, string password, string nonce, out IBuffer keyMaterial, out IBuffer iv);
     }
 }

--- a/SalesforceSDK/Salesforce.SDK.Store.Test/Source/Auth/AuthStorageHelperTest.cs
+++ b/SalesforceSDK/Salesforce.SDK.Store.Test/Source/Auth/AuthStorageHelperTest.cs
@@ -82,7 +82,7 @@ namespace Salesforce.SDK.Auth
             MethodInfo persist = auth.GetDeclaredMethod("PersistEncryptionSettings");
             MethodInfo delete = auth.GetDeclaredMethod("DeleteEncryptionSettings");
             
-            persist.Invoke(authStorageHelper, new object[] { Password, Salt, null });
+            persist.Invoke(authStorageHelper, new object[] { Password, Salt });
             CheckEncryptionSettings(true);
             delete.Invoke(authStorageHelper, null);
             CheckEncryptionSettings(false);
@@ -119,7 +119,7 @@ namespace Salesforce.SDK.Auth
             AuthStorageHelper authStorageHelper = AuthStorageHelper.GetAuthStorageHelper();
             TypeInfo auth = authStorageHelper.GetType().GetTypeInfo();
             MethodInfo tryRetrieve = auth.GetDeclaredMethod("TryRetrieveEncryptionSettings");
-            var parameters = new object[] {null, null, null};
+            var parameters = new object[] {null, null};
             var success = (bool)tryRetrieve.Invoke(authStorageHelper, parameters);
             if (!exists)
             {

--- a/SalesforceSDK/Salesforce.SDK.Store.Test/Source/Auth/AuthStorageHelperTest.cs
+++ b/SalesforceSDK/Salesforce.SDK.Store.Test/Source/Auth/AuthStorageHelperTest.cs
@@ -39,11 +39,7 @@ namespace Salesforce.SDK.Auth
         [TestInitialize]
         public void Setup()
         {
-            var settings = new EncryptionSettings(new HmacSHA256KeyGenerator())
-            {
-                Password = "mypassword",
-                Salt = "mysalt"
-            };
+            var settings = new EncryptionSettings(new HmacSHA256KeyGenerator());
             Encryptor.init(settings);
         }
 

--- a/SalesforceSDK/Salesforce.SDK.Store.Test/Source/SmartStore/SmartSyncTests.cs
+++ b/SalesforceSDK/Salesforce.SDK.Store.Test/Source/SmartStore/SmartSyncTests.cs
@@ -63,11 +63,7 @@ namespace Salesforce.SDK.SmartStore.Store
         [ClassInitialize]
         public static async Task TestSetup(TestContext context)
         {
-            var settings = new EncryptionSettings(new HmacSHA256KeyGenerator())
-            {
-                Password = "mypassword",
-                Salt = "mysalt"
-            };
+            var settings = new EncryptionSettings(new HmacSHA256KeyGenerator());
             Encryptor.init(settings);
             var options = new LoginOptions(TestCredentials.LoginUrl, TestCredentials.ClientId, TestCallbackUrl, "mobile",
                 TestScopes);

--- a/SalesforceSDK/Salesforce.Sample.NativeSmartStoreSample/Salesforce.Sample.NativeSmartStoreSample.Shared/App.xaml.cs
+++ b/SalesforceSDK/Salesforce.Sample.NativeSmartStoreSample/Salesforce.Sample.NativeSmartStoreSample.Shared/App.xaml.cs
@@ -41,11 +41,7 @@ namespace Salesforce.Sample.NativeSmartStoreSample.Shared
         /// <returns></returns>
         protected override Salesforce.SDK.Source.Settings.SalesforceConfig InitializeConfig()
         {         
-            EncryptionSettings settings = new EncryptionSettings(new HmacSHA256KeyGenerator())
-            {
-                Password = "fbeffb40-aac6-4ea5-a4cf-388dccdfc93d",
-                Salt = "9ca01492-e55a-4f30-afe2-a3783462f981"
-            };
+            EncryptionSettings settings = new EncryptionSettings(new HmacSHA256KeyGenerator());
             Encryptor.init(settings);
             Config config = SalesforceConfig.RetrieveConfig<Config>();
             if (config == null)

--- a/SalesforceSDK/Salesforce.Sample.RestExplorer.Phone/App.xaml.cs
+++ b/SalesforceSDK/Salesforce.Sample.RestExplorer.Phone/App.xaml.cs
@@ -113,11 +113,7 @@ namespace Salesforce.Sample.RestExplorer.Phone
 
         protected override SalesforceConfig InitializeConfig()
         {
-            var settings = new EncryptionSettings(new HmacSHA256KeyGenerator())
-            {
-                Password = "mypassword",
-                Salt = "mysalt"
-            };
+            var settings = new EncryptionSettings(new HmacSHA256KeyGenerator());
             Encryptor.init(settings);
             var config = SalesforceConfig.RetrieveConfig<Config>();
             if (config == null)

--- a/SalesforceSDK/Salesforce.Sample.RestExplorer.Store/App.xaml.cs
+++ b/SalesforceSDK/Salesforce.Sample.RestExplorer.Store/App.xaml.cs
@@ -69,11 +69,7 @@ namespace Salesforce.Sample.RestExplorer.Store
 
         protected override SalesforceConfig InitializeConfig()
         {
-            var settings = new EncryptionSettings(new HmacSHA256KeyGenerator())
-            {
-                Password = "mypassword",
-                Salt = "mysalt"
-            };
+            var settings = new EncryptionSettings(new HmacSHA256KeyGenerator());
             Encryptor.init(settings);
             var config = SalesforceConfig.RetrieveConfig<Config>();
             if (config == null)

--- a/SalesforceSDK/Salesforce.Sample.Salesforce1.Container/Salesforce.Sample.Salesforce1.Container.Shared/App.xaml.cs
+++ b/SalesforceSDK/Salesforce.Sample.Salesforce1.Container/Salesforce.Sample.Salesforce1.Container.Shared/App.xaml.cs
@@ -66,11 +66,7 @@ namespace Salesforce.Sample.Salesforce1.Container
 
         protected override SalesforceConfig InitializeConfig()
         {
-            var settings = new EncryptionSettings(new HmacSHA256KeyGenerator())
-            {
-                Password = "supercalifragilisticexpialidocious",
-                Salt = "friesaresaltyforsure"
-            };
+            var settings = new EncryptionSettings(new HmacSHA256KeyGenerator());
             Encryptor.init(settings);
             var config = SalesforceConfig.RetrieveConfig<Config>();
             if (config == null)

--- a/SalesforceSDK/Salesforce.Sample.SmartSyncExplorer/Salesforce.Sample.SmartSyncExplorer.Shared/App.xaml.cs
+++ b/SalesforceSDK/Salesforce.Sample.SmartSyncExplorer/Salesforce.Sample.SmartSyncExplorer.Shared/App.xaml.cs
@@ -34,11 +34,7 @@ namespace Salesforce.Sample.SmartSyncExplorer.Shared
         /// <returns></returns>
         protected override SalesforceConfig InitializeConfig()
         {
-            var settings = new EncryptionSettings(new HmacSHA256KeyGenerator())
-            {
-                Password = "fbeffb40-aac6-4ea5-a4cf-388dccdfc93d",
-                Salt = "9ca01492-e55a-4f30-afe2-a3783462f981"
-            };
+            var settings = new EncryptionSettings(new HmacSHA256KeyGenerator());
             Encryptor.init(settings);
             Config config = SalesforceConfig.RetrieveConfig<Config>() ?? new Config();
             return config;


### PR DESCRIPTION
Added in code to store and retrieve the password and salt we use when initialized encryption into the password vault.  Added unit test for the new code, and updated a failing unit test in AuthStorageHelperTests.

@smcnulty-sfdc @kchitalia @qren