### PR TITLE
Bug fix for suspension manager crashing when calling Frame.GetNavigationState()

### DIFF
--- a/SalesforceSDK/Salesforce.SDK.App/Auth/PincodeDialog.xaml.cs
+++ b/SalesforceSDK/Salesforce.SDK.App/Auth/PincodeDialog.xaml.cs
@@ -63,14 +63,20 @@ namespace Salesforce.SDK.Auth
 
         protected override void OnNavigatedTo(NavigationEventArgs e)
         {
-            if (e.Parameter != null && !(e.Parameter is PincodeOptions))
+            // start with a default PincodeOptions object
+            Options = new PincodeOptions(PincodeOptions.PincodeScreen.Create, AccountManager.GetAccount(), "");
+            if (e.Parameter != null)
             {
-                Options = new PincodeOptions(PincodeOptions.PincodeScreen.Create, AccountManager.GetAccount(), "");
+                try
+                {
+                    Options = PincodeOptions.FromJson((string)e.Parameter);
+                }
+                catch
+                {
+                    // it is not a valid PincodeOptions object so ignore and keep using the default one
+                }
             }
-            else
-            {
-                Options = e.Parameter as PincodeOptions;
-            }
+
             if (Options != null)
             {
                 switch (Options.Screen)
@@ -174,7 +180,11 @@ namespace Salesforce.SDK.Auth
             {
                 PlatformAdapter.SendToCustomLogger("PincodeDialog.CreateClicked - Going to confirmation page", LoggingLevel.Verbose);
                 var options = new PincodeOptions(PincodeOptions.PincodeScreen.Confirm, Options.User, Passcode.Password);
-                Frame.Navigate(typeof (PincodeDialog), options);
+                // As per MSDN documentation (https://msdn.microsoft.com/en-us/library/windows/apps/hh702394.aspx)
+                // the second param of Frame.Navigate must be a basic type otherwise Suspension manager will crash
+                // when serializing frame's state. So we serialize custom object using Json and pass that as the 
+                // second param to avoid this crash.
+                Frame.Navigate(typeof (PincodeDialog), PincodeOptions.ToJson(options));
             }
             else
             {
@@ -268,7 +278,11 @@ namespace Salesforce.SDK.Auth
             if (PincodeOptions.PincodeScreen.Confirm == Options.Screen)
             {
                 var options = new PincodeOptions(PincodeOptions.PincodeScreen.Create, Options.User, "");
-                Frame.Navigate(typeof (PincodeDialog), options);
+                // As per MSDN documentation (https://msdn.microsoft.com/en-us/library/windows/apps/hh702394.aspx)
+                // the second param of Frame.Navigate must be a basic type otherwise Suspension manager will crash
+                // when serializing frame's state. So we serialize custom object using Json and pass that as the 
+                // second param to avoid this crash.
+                Frame.Navigate(typeof (PincodeDialog), PincodeOptions.ToJson(options));
             }
         }
     }

--- a/SalesforceSDK/Salesforce.SDK.App/Auth/PincodeManager.cs
+++ b/SalesforceSDK/Salesforce.SDK.App/Auth/PincodeManager.cs
@@ -139,7 +139,11 @@ namespace Salesforce.SDK.Auth
                         }
                         if (options != null)
                         {
-                            frame.Navigate(typeof (PincodeDialog), options);
+                            // As per MSDN documentation (https://msdn.microsoft.com/en-us/library/windows/apps/hh702394.aspx)
+                            // the second param of Frame.Navigate must be a basic type otherwise Suspension manager will crash
+                            // when serializing frame's state. So we serialize custom object using Json and pass that as the 
+                            // second param to avoid this crash.
+                            frame.Navigate(typeof (PincodeDialog), PincodeOptions.ToJson(options));
                         }
                     }
                 });

--- a/SalesforceSDK/Salesforce.SDK.App/Auth/PincodeOptions.cs
+++ b/SalesforceSDK/Salesforce.SDK.App/Auth/PincodeOptions.cs
@@ -48,5 +48,25 @@ namespace Salesforce.SDK.Auth
         public PincodeScreen Screen { get; private set; }
         public string Passcode { get; private set; }
         public MobilePolicy Policy { get; set; }
+
+        /// <summary>
+        ///     Serialize PincodeOptions object as a JSON string
+        /// </summary>
+        /// <param name="pincodeOptions"></param>
+        /// <returns></returns>
+        public static string ToJson(PincodeOptions pincodeOptions)
+        {
+            return JsonConvert.SerializeObject(pincodeOptions);
+        }
+
+        /// <summary>
+        ///     Deserialize PincodeOptions from a JSON string
+        /// </summary>
+        /// <param name="pincodeOptionsJson"></param>
+        /// <returns></returns>
+        public static PincodeOptions FromJson(string pincodeOptionsJson)
+        {
+            return JsonConvert.DeserializeObject<PincodeOptions>(pincodeOptionsJson);
+        }
     }
 }


### PR DESCRIPTION
These changes fix the crash that  suspension manager hits when calling Frame.GetNavigationState(). As per MSDN documentation (https://msdn.microsoft.com/en-us/library/windows/apps/hh702394.aspx) the second param of Frame.Navigate must be a basic type otherwise suspension manager will crash when serializing frame's state. So we serialize custom objects using Json and pass that as the second param to avoid this crash.