### PR TITLE
Do not show Authentication failure dialog when hitting back button on login page on Phone

### DIFF
--- a/SalesforceSDK/Salesforce.SDK.Phone/Source/Pages/AccountPage.xaml.cs
+++ b/SalesforceSDK/Salesforce.SDK.Phone/Source/Pages/AccountPage.xaml.cs
@@ -109,6 +109,10 @@ namespace Salesforce.SDK.Source.Pages
                     SetupAccountPage();
                 }
             }
+            else if (webResult.ResponseStatus == WebAuthenticationStatus.UserCancel)
+            {
+                SetupAccountPage();
+            }
             else
             {
                 DisplayErrorDialog(LocalizedStrings.GetString("generic_authentication_error"));


### PR DESCRIPTION
Fix bug W-2534535