### PR TITLE
Remove cordova.define for accountmanager proxy

### DIFF
--- a/SalesforceSDK/CordovaPluginJavascript/com.salesforce.plugin.accountmanagerProxy.js
+++ b/SalesforceSDK/CordovaPluginJavascript/com.salesforce.plugin.accountmanagerProxy.js
@@ -1,4 +1,4 @@
-cordova.define("com.salesforce.SalesforceAccountManagerProxy", function(require, exports, module) { /*
+ /*
  * Copyright (c) 2015, salesforce.com, inc.
  * All rights reserved.
  *
@@ -24,7 +24,7 @@ cordova.define("com.salesforce.SalesforceAccountManagerProxy", function(require,
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-var SALESFORCE_MOBILE_SDK_VERSION = "3.3.0";
+var SALESFORCE_MOBILE_SDK_VERSION = "4.0.0";
 var SERVICE = "com.salesforce.sfaccountmanager";
 
 var exec = require("com.salesforce.util.exec").exec;
@@ -90,5 +90,3 @@ module.exports = {
 };
 
 require("cordova/exec/proxy").add(SERVICE, module.exports);
-
-});


### PR DESCRIPTION
Removing this line as its added by cordova.js when we add the plugin and build the project.