### PR TITLE
expose HasResponse through RestResponse

### DIFF
--- a/SalesforceSDK/Core/Rest/IRestResponse.cs
+++ b/SalesforceSDK/Core/Rest/IRestResponse.cs
@@ -36,6 +36,11 @@ namespace Salesforce.SDK.Rest
         /// <summary>
         /// True if REST request was successfully executed
         /// </summary>
+        bool HasResponse { get; }
+
+        /// <summary>
+        /// True if REST request was successfully executed
+        /// </summary>
         bool Success { get; }
 
         /// <summary>

--- a/SalesforceSDK/Core/Rest/RestClient.cs
+++ b/SalesforceSDK/Core/Rest/RestClient.cs
@@ -98,11 +98,6 @@ namespace Salesforce.SDK.Rest
                     new HttpCall(request.Method, headers, url, request.RequestBody, request.ContentType).Execute()
                         .ConfigureAwait(false);
 
-            if (!call.HasResponse)
-            {
-                throw call.Error;
-            }
-
             if (call.StatusCode == HttpStatusCode.Unauthorized || call.StatusCode == HttpStatusCode.Forbidden)
             {
                 if (retryInvalidToken && _accessTokenProvider != null)

--- a/SalesforceSDK/Core/Rest/RestResponse.cs
+++ b/SalesforceSDK/Core/Rest/RestResponse.cs
@@ -45,6 +45,8 @@ namespace Salesforce.SDK.Rest
             _call = call;
         }
 
+        public bool HasResponse { get { return _call.HasResponse; } }
+
         public bool Success
         {
             get { return _call.Success; }


### PR DESCRIPTION
There was no way for us to detect that a Rest call failed because we were offline. By exposing HasResponse through RestClient (instead of throwing an exception) we can determine that the call failed because the app was offline.