### PR TITLE
handle oauth failures in rest client, move some Account logic from au…

### DIFF
--- a/SalesforceSDK/Core/Auth/Account.cs
+++ b/SalesforceSDK/Core/Auth/Account.cs
@@ -74,10 +74,11 @@ namespace Salesforce.SDK.Auth
         public string CommunityId { get; set; }
         public string CommunityUrl { get; set; }
 
+        public string OrganizationId { get; set; }
+
         [JsonProperty]
         public MobilePolicy Policy { get; internal set; }
-
-
+        
         /// <summary>
         ///     Serialize Account object as a JSON string
         /// </summary>

--- a/SalesforceSDK/Core/Auth/Account.cs
+++ b/SalesforceSDK/Core/Auth/Account.cs
@@ -37,8 +37,8 @@ namespace Salesforce.SDK.Auth
         public const string InternalCommunityId = "000000000000000000";
 
         /// <summary>
-        ///     Constructor for Account
-        ///     NB: the Account is not stored anywhere until we call PersistCredentialsAsync on the IAuthStorageHelper
+        ///  Constructor for Account
+        ///  NB: the Account is not stored anywhere until we call PersistCurrentAccountAsync on the IAuthStorageHelper
         /// </summary>
         /// <param name="loginUrl"></param>
         /// <param name="clientId"></param>

--- a/SalesforceSDK/Core/Auth/AccountManager.cs
+++ b/SalesforceSDK/Core/Auth/AccountManager.cs
@@ -56,7 +56,7 @@ namespace Salesforce.SDK.Auth
                 // This check is necessary as sometimes CurrentAccount.Set is called
                 // even if the same account was already set, so use the unique combo of
                 // InstanceUrl and UserId to tell if the account has actually changed (login/logout).
-                if (oldAccount?.InstanceUrl != value?.InstanceUrl && oldAccount?.UserId != value?.UserId)
+                if (oldAccount?.OrganizationId != value?.OrganizationId && oldAccount?.UserId != value?.UserId)
                 {
                     RaiseAuthenticatedAccountChangedEvent(oldAccount, value);
                 }
@@ -204,6 +204,8 @@ namespace Salesforce.SDK.Auth
                 account.UserId = identity.UserId;
                 account.UserName = identity.UserName;
                 account.Policy = identity.MobilePolicy;
+                account.OrganizationId = identity.OrganizationId;
+
                 await AuthStorageHelper.PersistCurrentAccountAsync(account);
 
                 LoggedInAccount = account;

--- a/SalesforceSDK/Core/Auth/AccountManager.cs
+++ b/SalesforceSDK/Core/Auth/AccountManager.cs
@@ -37,12 +37,32 @@ using Salesforce.SDK.Rest;
 namespace Salesforce.SDK.Auth
 {
     /// <summary>
-    ///     Class providing (static) methods for creating/deleting or retrieving an Account
+    /// Class providing (static) methods for creating/deleting or retrieving an Account
     /// </summary>
     public class AccountManager
     {
         private static IAuthHelper AuthStorageHelper => SDKServiceLocator.Get<IAuthHelper>();
         private static ILoggingService LoggingService => SDKServiceLocator.Get<ILoggingService>();
+
+        private static Account _loggedInAccount;
+        private static Account LoggedInAccount
+        {
+            set
+            {
+                var oldAccount = _loggedInAccount;
+                _loggedInAccount = value;
+
+                // Raise the event in AccountManager if this is a different account.
+                // This check is necessary as sometimes CurrentAccount.Set is called
+                // even if the same account was already set, so use the unique combo of
+                // InstanceUrl and UserId to tell if the account has actually changed (login/logout).
+                if (oldAccount?.InstanceUrl != value?.InstanceUrl && oldAccount?.UserId != value?.UserId)
+                {
+                    RaiseAuthenticatedAccountChangedEvent(oldAccount, value);
+                }
+            }
+            get { return _loggedInAccount; }
+        }
 
         /// <summary>
         /// This event notifies consumers that the authenticated account has changed.
@@ -55,71 +75,90 @@ namespace Salesforce.SDK.Auth
         /// an account changes but the event belongs in the AccountManager class, so this method is necessary
         /// to enable AuthStorageHelper to raise that event.
         /// </summary>
-        public static void RaiseAuthenticatedAccountChangedEvent(Account oldAccount, Account newAccount)
+        private static void RaiseAuthenticatedAccountChangedEvent(Account oldAccount, Account newAccount)
         {
             AuthenticatedAccountChanged?.Invoke(new AuthenticatedAccountChangedEventArgs(oldAccount, newAccount));
         }
 
         /// <summary>
-        ///     Delete Account for currently authenticated user
+        /// Delete Account (log out) for currently authenticated user
         /// </summary>
         public static void DeleteAccount()
         {
-            Account account = GetAccount();
-            AuthStorageHelper.DeletePersistedCredentials(account.UserName, account.UserId);
+            var account = GetAccount();
+
+            if (account == null)
+            {
+                return;
+            }
+
+            AuthStorageHelper.DeletePersistedAccount(account.UserName, account.UserId);
+
+            LoggedInAccount = null;
         }
 
         public static Dictionary<string, Account> GetAccounts()
         {
-            return AuthStorageHelper.RetrievePersistedCredentials();
+            return AuthStorageHelper.RetrieveAllPersistedAccounts();
         }
 
         /// <summary>
-        ///     Return Account for currently authenticated user
+        ///  Return Account for currently authenticated user
         /// </summary>
         /// <returns></returns>
         public static Account GetAccount()
         {
-            return AuthStorageHelper.RetrieveCurrentAccount();
+            return LoggedInAccount ?? (LoggedInAccount = AuthStorageHelper.RetrieveCurrentAccount());
         }
 
-        public static async Task<bool> SwitchToAccount(Account account)
+        public static async Task<bool> SwitchToAccount(Account newAccount)
         {
-            if (account != null && account.UserId != null)
+            var oldAccount = LoggedInAccount;
+
+            if (newAccount?.UserId != null)
             {
+                // save current user pin timer
                 AuthStorageHelper.SavePinTimer();
-                await AuthStorageHelper.PersistCredentialsAsync(account);
+
+                await AuthStorageHelper.PersistCurrentAccountAsync(newAccount);
+
                 var client = SDKManager.GlobalClientManager.PeekRestClient();
                 if (client != null)
                 {
-                    AuthStorageHelper.ClearCookies(account.GetLoginOptions());
-                    IdentityResponse identity = await OAuth2.CallIdentityServiceAsync(account.IdentityUrl, client);
+                    await AuthStorageHelper.ClearCookiesAsync(newAccount.GetLoginOptions());
+                    var identity = await OAuth2.CallIdentityServiceAsync(newAccount.IdentityUrl, client);
                     if (identity != null)
                     {
-                        account.UserId = identity.UserId;
-                        account.UserName = identity.UserName;
-                        account.Policy = identity.MobilePolicy;
-                        await AuthStorageHelper.PersistCredentialsAsync(account);
+                        newAccount.UserId = identity.UserId;
+                        newAccount.UserName = identity.UserName;
+                        newAccount.Policy = identity.MobilePolicy;
+                        await AuthStorageHelper.PersistCurrentAccountAsync(newAccount);
                     }
                     AuthStorageHelper.RefreshCookies();
                     LoggingService.Log("switched accounts, result = true", LoggingLevel.Verbose);
                     return true;
                 }
+
+                // log new user in
+                LoggedInAccount = newAccount;
+
+                RaiseAuthenticatedAccountChangedEvent(oldAccount, newAccount);
             }
+
             LoggingService.Log("switched accounts, result = false", LoggingLevel.Verbose);
             return false;
         }
 
         public static void WipeAccounts()
         {
-            AuthStorageHelper.DeletePersistedCredentials();
+            AuthStorageHelper.DeleteAllPersistedAccounts();
             AuthStorageHelper.WipePincode();
             SwitchAccount();
         }
 
         public static void SwitchAccount()
         {
-            AuthStorageHelper.StartLoginFlow();
+            AuthStorageHelper.StartLoginFlowAsync();
         }
 
         /// <summary>
@@ -130,11 +169,21 @@ namespace Salesforce.SDK.Auth
         public static async Task<Account> CreateNewAccount(LoginOptions loginOptions, AuthResponse authResponse)
         {
             LoggingService.Log("Create account object", LoggingLevel.Verbose);
-            var account = new Account(loginOptions.LoginUrl, loginOptions.ClientId, loginOptions.CallbackUrl,
+
+            var account = new Account(
+                loginOptions.LoginUrl, 
+                loginOptions.ClientId, 
+                loginOptions.CallbackUrl,
                 loginOptions.Scopes,
-                authResponse.InstanceUrl, authResponse.IdentityUrl, authResponse.AccessToken, authResponse.RefreshToken);
-            account.CommunityId = authResponse.CommunityId;
-            account.CommunityUrl = authResponse.CommunityUrl;
+                authResponse.InstanceUrl, 
+                authResponse.IdentityUrl, 
+                authResponse.AccessToken, 
+                authResponse.RefreshToken)
+            {
+                CommunityId = authResponse.CommunityId,
+                CommunityUrl = authResponse.CommunityUrl
+            };
+
             var cm = new ClientManager();
             cm.PeekRestClient();
             IdentityResponse identity = null;
@@ -149,12 +198,15 @@ namespace Salesforce.SDK.Auth
                 LoggingService.Log(ex, LoggingLevel.Critical);
                 Debug.WriteLine("Error retrieving account identity");
             }
+
             if (identity != null)
             {
                 account.UserId = identity.UserId;
                 account.UserName = identity.UserName;
                 account.Policy = identity.MobilePolicy;
-                await AuthStorageHelper.PersistCredentialsAsync(account);
+                await AuthStorageHelper.PersistCurrentAccountAsync(account);
+
+                LoggedInAccount = account;
             }
             LoggingService.Log("Finished creating account", LoggingLevel.Verbose);
             return account;

--- a/SalesforceSDK/Core/Auth/IAuthHelper.cs
+++ b/SalesforceSDK/Core/Auth/IAuthHelper.cs
@@ -31,30 +31,82 @@ using System.Threading.Tasks;
 namespace Salesforce.SDK.Auth
 {
     /// <summary>
-    ///     Interface for auth related operations that are implemented in the platform specific assemblies
+    /// Interface for auth related operations that are implemented in the platform specific assemblies
     /// </summary>
     public interface IAuthHelper
     {
         /// <summary>
-        ///     Kicks off ogin flow
+        /// Shows the login UI
         /// </summary>
-        void StartLoginFlow();
+        Task StartLoginFlowAsync();
 
         /// <summary>
-        ///     Called once the login flow has completed, creates the account
+        /// This should be called when login is complete. A new account is created
+        /// in the AccountManager and the pincode screen is shown if needeed
         /// </summary>
         /// <param name="loginOptions"></param>
         /// <param name="authResponse"></param>
-        void EndLoginFlow(LoginOptions loginOptions, AuthResponse authResponse);
+        Task OnLoginCompleteAsync(LoginOptions loginOptions, AuthResponse authResponse);
 
-        Task PersistCredentialsAsync(Account account);
+        /// <summary>
+        /// Refresh webview cookies
+        /// </summary>
         void RefreshCookies();
-        void ClearCookies(LoginOptions options);
-        void DeletePersistedCredentials(string userName, string userId);
-        Dictionary<string, Account> RetrievePersistedCredentials();
+
+        /// <summary>
+        /// Clears webview cookies
+        /// </summary>
+        /// <param name="options"></param>
+        Task ClearCookiesAsync(LoginOptions options);
+
+        /// <summary>
+        /// Save the current user's credentials to secure storage
+        /// 
+        /// NOTE This should only be called by the AccountManager all login/logout
+        /// functions should be done through the AccountManager
+        /// </summary>
+        /// <param name="account"></param>
+        /// <returns></returns>
+        Task PersistCurrentAccountAsync(Account account);
+
+        /// <summary>
+        /// Delete the specified user's credentials from secure storage
+        /// 
+        /// NOTE This should only be called by the AccountManager all login/logout
+        /// functions should be done through the AccountManager
+        /// </summary>
+        /// <param name="userName"></param>
+        /// <param name="userId"></param>
+        void DeletePersistedAccount(string userName, string userId);
+
+        /// <summary>
+        /// Delete all persisted accounts
+        /// 
+        /// NOTE This should only be called by the AccountManager all login/logout
+        /// functions should be done through the AccountManager
+        /// </summary>
+        void DeleteAllPersistedAccounts();
+
+        /// <summary>
+        /// Retrieves all accounts stored in secure storage
+        /// </summary>
+        /// <returns></returns>
+        Dictionary<string, Account> RetrieveAllPersistedAccounts();
+
+        /// <summary>
+        /// Retrieves the currently logged in user from secure storage
+        /// </summary>
+        /// <returns></returns>
         Account RetrieveCurrentAccount();
+
+        /// <summary>
+        /// Saves the pin timer
+        /// </summary>
         void SavePinTimer();
-        void DeletePersistedCredentials();
+
+        /// <summary>
+        /// Clear the pincode timer
+        /// </summary>
         void WipePincode();
     }
 }

--- a/SalesforceSDK/Core/Auth/OAuth2.cs
+++ b/SalesforceSDK/Core/Auth/OAuth2.cs
@@ -322,7 +322,7 @@ namespace Salesforce.SDK.Auth
 
                 account.AccessToken = response.AccessToken;
 
-                await SDKServiceLocator.Get<IAuthHelper>().PersistCredentialsAsync(account);
+                await SDKServiceLocator.Get<IAuthHelper>().PersistCurrentAccountAsync(account);
             }
             catch (DeviceOfflineException ex)
             {
@@ -381,7 +381,7 @@ namespace Salesforce.SDK.Auth
 
         public static void ClearCookies(LoginOptions loginOptions)
         {
-            AuthHelper.ClearCookies(loginOptions);
+            AuthHelper.ClearCookiesAsync(loginOptions);
         }
 
         /// <summary>

--- a/SalesforceSDK/Core/Auth/SDKManager.cs
+++ b/SalesforceSDK/Core/Auth/SDKManager.cs
@@ -34,8 +34,6 @@ namespace Salesforce.SDK.Auth
 {
     public class SDKManager
     {
-
-
         /// <summary>
         /// The root application page your app should move to after login/pincode. For UI apps only.
         /// </summary>
@@ -45,8 +43,8 @@ namespace Salesforce.SDK.Auth
         /// Set RootAccountPage if you wish to provide your own account settings page.
         /// 
         /// If you do wish to do this, be warned that you should still call,
-        /// 1. PlatformAdapter.Resolve<IAuthHelper>().StartLoginFlow();
-        /// 2. PlatformAdapter.Resolve<IAuthHelper>().EndLoginFlow(loginOptions, authResponse);
+        /// 1. PlatformAdapter.Resolve<IAuthHelper>().StartLoginFlowAsync();
+        /// 2. PlatformAdapter.Resolve<IAuthHelper>().OnLoginCompleteAsync(loginOptions, authResponse);
         /// Both methods will assist in displaying and finishing the login steps, including creation of the account and pincode settings.
         /// 
         /// You can also provide this own functionality yourself. Please look at AuthHelper.cs in the SDK.Phone and SDK.Store application for example code and work from there
@@ -59,8 +57,6 @@ namespace Salesforce.SDK.Auth
         ///     The global client manager is provided for ease of accessing clients such as the RestClient.
         /// </summary>
         public static ClientManager GlobalClientManager { get; private set; }
-
-        
 
         /// <summary>
         ///     The current configuration for the application.

--- a/SalesforceSDK/Core/Net/HttpCall.cs
+++ b/SalesforceSDK/Core/Net/HttpCall.cs
@@ -324,8 +324,14 @@ namespace Salesforce.SDK.Net
             }
             catch (HttpRequestException ex)
             {
-                _httpCallErrorException = new DeviceOfflineException("Request failed to send, most likely because we were offline", ex);
-                message = null;
+                _httpCallErrorException =
+                    new DeviceOfflineException("Request failed to send, most likely because we were offline", ex);
+                return this;
+            }
+            catch (WebException ex)
+            {
+                _httpCallErrorException =
+                    new DeviceOfflineException("Request failed to send, most likely because we were offline", ex);
                 return this;
             }
 
@@ -351,8 +357,8 @@ namespace Salesforce.SDK.Net
                 // if we are offline and fiddler is running, we will get a BadGateway so wrap the exception in
                 // a DeviceOfflineException
 
-                _httpCallErrorException = response.StatusCode == HttpStatusCode.BadGateway
-                    ? new DeviceOfflineException("Could not connect to server because of a bad connection", ex)
+                _httpCallErrorException = response.StatusCode == HttpStatusCode.BadGateway 
+                    ? new DeviceOfflineException("Could not connect to server because of a bad connection", ex) 
                     : ex;
             }
 

--- a/SalesforceSDK/Core/Rest/ClientManager.cs
+++ b/SalesforceSDK/Core/Rest/ClientManager.cs
@@ -29,6 +29,7 @@ using System;
 using System.Threading.Tasks;
 using Salesforce.SDK.Auth;
 using Salesforce.SDK.Core;
+using Salesforce.SDK.Exceptions;
 using Salesforce.SDK.Logging;
 
 namespace Salesforce.SDK.Rest
@@ -40,6 +41,7 @@ namespace Salesforce.SDK.Rest
     /// </summary>
     public class ClientManager
     {
+        private static ILoggingService LoggingService => SDKServiceLocator.Get<ILoggingService>();
         private static IAuthHelper AuthHelper => SDKServiceLocator.Get<IAuthHelper>();
         /// <summary>
         ///     Logs currently authenticated user out by deleting locally persisted credentials and invoking the server to revoke
@@ -53,7 +55,7 @@ namespace Salesforce.SDK.Rest
             {
                 LoginOptions options = account.GetLoginOptions();
                 AccountManager.DeleteAccount();
-                AuthHelper.ClearCookies(options);
+                await AuthHelper.ClearCookiesAsync(options);
                 bool loggedOut = await OAuth2.RevokeAuthTokenAsync(options, account.RefreshToken);
                 if (loggedOut)
                 {
@@ -78,7 +80,24 @@ namespace Salesforce.SDK.Rest
                     async () =>
                     {
                         account = AccountManager.GetAccount();
-                        account = await OAuth2.RefreshAuthTokenAsync(account);
+
+                        try
+                        {
+                            account = await OAuth2.RefreshAuthTokenAsync(account);
+                        }
+                        catch (DeviceOfflineException)
+                        {
+                            LoggingService.Log("Could not refresh the token because device is offline", LoggingLevel.Warning);
+                            return null;
+                        }
+                        catch (OAuthException ex)
+                        {
+                            LoggingService.Log("Failed to refresh the token, logging the user out", LoggingLevel.Warning);
+                            LoggingService.Log(ex, LoggingLevel.Error);
+
+                            // we failed to refresh the token, we have to log the user out
+                            await Logout();
+                        }
 
                         return account.AccessToken;
                     }
@@ -98,7 +117,7 @@ namespace Salesforce.SDK.Rest
             {
                 try
                 {
-                    AuthHelper.StartLoginFlow();
+                    AuthHelper.StartLoginFlowAsync();
                 }
                 catch (InvalidOperationException)
                 {

--- a/SalesforceSDK/Core/Rest/RestRequest.cs
+++ b/SalesforceSDK/Core/Rest/RestRequest.cs
@@ -127,8 +127,9 @@ namespace Salesforce.SDK.Rest
         /// </summary>
         /// <param name="method">The HTTP method for the request (GET/POST/DELETE etc)</param>
         /// <param name="path">The URI path, this will automatically be resolved against the users current instance host.</param>
-        public RestRequest(HttpMethod method, string path)
-            : this(method, path, null, ContentTypeValues.None, null)
+        /// <param name="additionalHeaders">Optional - add additional headers to request</param>
+        public RestRequest(HttpMethod method, string path, Dictionary<string, string> additionalHeaders = null )
+            : this(method, path, null, ContentTypeValues.None, additionalHeaders)
         {
         }
 

--- a/SalesforceSDK/Hybrid/Auth/Account.cs
+++ b/SalesforceSDK/Hybrid/Auth/Account.cs
@@ -14,7 +14,7 @@ namespace Salesforce.SDK.Hybrid.Auth
 
         /// <summary>
         ///     Constructor for Account
-        ///     NB: the Account is not stored anywhere until we call PersistCredentialsAsync on the IAuthStorageHelper
+        ///     NB: the Account is not stored anywhere until we call PersistCurrentAccountAsync on the IAuthStorageHelper
         /// </summary>
         /// <param name="loginUrl"></param>
         /// <param name="clientId"></param>

--- a/SalesforceSDK/Salesforce.SDK.Tests/Source/Auth/AuthStorageHelperTest.cs
+++ b/SalesforceSDK/Salesforce.SDK.Tests/Source/Auth/AuthStorageHelperTest.cs
@@ -74,9 +74,9 @@ namespace Salesforce.SDK.Auth
             AuthStorageHelper authStorageHelper = AuthStorageHelper.GetAuthStorageHelper();
             CheckAccount(account, false);
             TypeInfo auth = authStorageHelper.GetType().GetTypeInfo();
-            MethodInfo persist = auth.GetDeclaredMethod("PersistCredentialsAsync");
+            MethodInfo persist = auth.GetDeclaredMethod("PersistCurrentAccountAsync");
             MethodInfo delete =
-                auth.GetDeclaredMethods("DeletePersistedCredentials")
+                auth.GetDeclaredMethods("DeleteAllPersistedAccounts")
                     .First(method => method.GetParameters().Count() == 2);
             persist.Invoke(authStorageHelper, new object[] {account});
             CheckAccount(account, true);
@@ -103,7 +103,7 @@ namespace Salesforce.SDK.Auth
         {
             AuthStorageHelper authStorageHelper = AuthStorageHelper.GetAuthStorageHelper();
             TypeInfo auth = authStorageHelper.GetType().GetTypeInfo();
-            MethodInfo retrieve = auth.GetDeclaredMethod("RetrievePersistedCredentials");
+            MethodInfo retrieve = auth.GetDeclaredMethod("RetrieveAllPersistedAccounts");
             var accounts = (Dictionary<string, Account>) retrieve.Invoke(authStorageHelper, null);
             if (!exists)
             {

--- a/SalesforceSDK/SmartSync/Model/SoqlSyncDownTarget.cs
+++ b/SalesforceSDK/SmartSync/Model/SoqlSyncDownTarget.cs
@@ -104,7 +104,7 @@ namespace Salesforce.SDK.SmartSync.Model
                 return null;
             }
 
-            var request = new RestRequest(HttpMethod.Get, NextRecordsUrl, null);
+            var request = new RestRequest(HttpMethod.Get, NextRecordsUrl);
             var response = await syncManager.SendRestRequest(request);
             JObject responseJson = response.AsJObject;
             var records = responseJson.ExtractValue<JArray>(Constants.Records);

--- a/SalesforceSDK/Universal/Auth/PincodeDialog.xaml.cs
+++ b/SalesforceSDK/Universal/Auth/PincodeDialog.xaml.cs
@@ -219,7 +219,7 @@ namespace Salesforce.SDK.Auth
             Account account = AccountManager.GetAccount();
             if (account == null)
             {
-                SDKServiceLocator.Get<IAuthHelper>().StartLoginFlow();
+                await SDKServiceLocator.Get<IAuthHelper>().StartLoginFlowAsync();
             }
             else if (AuthStorageHelper.ValidatePincode(Passcode.Password))
             {

--- a/SalesforceSDK/Universal/Native/NativeMainPage.cs
+++ b/SalesforceSDK/Universal/Native/NativeMainPage.cs
@@ -24,6 +24,8 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
+
+using System.Threading.Tasks;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Navigation;
 using Salesforce.SDK.App;
@@ -42,7 +44,7 @@ namespace Salesforce.SDK.Native
         {
             await SDKManager.GlobalClientManager.Logout();
 
-            CheckIfLoginNeeded();
+            await CheckIfLoginNeededAsync();
         }
 
         /// <summary>
@@ -50,21 +52,21 @@ namespace Salesforce.SDK.Native
         ///     If we are not already authenticated, this will kick off the login flow
         /// </summary>
         /// <param name="e"></param>
-        protected override void OnNavigatedTo(NavigationEventArgs e)
+        protected override async void OnNavigatedTo(NavigationEventArgs e)
         {
             base.OnNavigatedTo(e);
 
-            CheckIfLoginNeeded();
+            await CheckIfLoginNeededAsync();
         }
 
-        private void CheckIfLoginNeeded()
+        private async Task CheckIfLoginNeededAsync()
         {
             Account account = AccountManager.GetAccount();
             if (account == null)
             {
-                SDKServiceLocator.Get<ILoggingService>().Log("Account object is null, calling StartLoginFlow",
+                SDKServiceLocator.Get<ILoggingService>().Log("Account object is null, calling StartLoginFlowAsync",
                                                           LoggingLevel.Verbose);
-                SDKServiceLocator.Get<IAuthHelper>().StartLoginFlow();
+                await SDKServiceLocator.Get<IAuthHelper>().StartLoginFlowAsync();
             }
         }
     }

--- a/SalesforceSDK/Universal/Pages/AccountPage.xaml.cs
+++ b/SalesforceSDK/Universal/Pages/AccountPage.xaml.cs
@@ -251,7 +251,7 @@ namespace Salesforce.SDK.Pages
             loginOptions.DisplayType = LoginOptions.DefaultStoreDisplayType;
             var loginUri = new Uri(OAuth2.ComputeAuthorizationUrl(loginOptions));
             var callbackUri = new Uri(loginOptions.CallbackUrl);
-            SDKServiceLocator.Get<IAuthHelper>().ClearCookies(loginOptions);
+            await SDKServiceLocator.Get<IAuthHelper>().ClearCookiesAsync(loginOptions);
             WebAuthenticationResult webAuthenticationResult = null;
             var hasWebAuthErrors = false;
 
@@ -299,7 +299,7 @@ namespace Salesforce.SDK.Pages
                 {
                     AuthResponse authResponse = OAuth2.ParseFragment(responseUri.Fragment.Substring(1));
 
-                    SDKServiceLocator.Get<IAuthHelper>().EndLoginFlow(loginOptions, authResponse);
+                    await SDKServiceLocator.Get<IAuthHelper>().OnLoginCompleteAsync(loginOptions, authResponse);
                 }
             }
             else if (webAuthenticationResult.ResponseStatus == WebAuthenticationStatus.UserCancel)


### PR DESCRIPTION
This pullrequest does the following:

RestClient failures due to oauth token being revoked were not being handled, resulting in a crash - now if a token was revoked, we automatically log out.

Moves some AccountManager logic code which was in the StorageHelper class when really it was Account Management logic. Also did some general clean up in this class.

Async fixes - there were several methods which were async but not being properly awaited - fixed some of these but recommend a broader sweep is made of the code for these issues. Along with this fix, I renamed the appropriate methods with the "Async" suffix.

@kchitalia   