### PR TITLE
encode the query url part completedly specially for special charate, like plus etc

### DIFF
--- a/SalesforceSDK/Core/Rest/RestRequest.cs
+++ b/SalesforceSDK/Core/Rest/RestRequest.cs
@@ -267,7 +267,7 @@ namespace Salesforce.SDK.Rest
             if (fieldsList != null && fieldsList.Length > 0)
             {
                 path.Append("?fields=");
-                path.Append(Uri.EscapeUriString(string.Join(",", fieldsList)));
+                path.Append(Uri.EscapeDataString(string.Join(",", fieldsList)));
             }
 
             return new RestRequest(HttpMethod.Get, path.ToString());
@@ -337,7 +337,7 @@ namespace Salesforce.SDK.Rest
         {
             var path = new StringBuilder(RestAction.Search.Path(apiVersion));
             path.Append("?q=");
-            path.Append(Uri.EscapeUriString(q));
+            path.Append(Uri.EscapeDataString(q));
             return new RestRequest(HttpMethod.Get, path.ToString());
         }
 
@@ -352,7 +352,7 @@ namespace Salesforce.SDK.Rest
         {
             var path = new StringBuilder(RestAction.Query.Path(apiVersion));
             path.Append("?q=");
-            path.Append(Uri.EscapeUriString(q));
+            path.Append(Uri.EscapeDataString(q));
             return new RestRequest(HttpMethod.Get, path.ToString());
         }
     }

--- a/SalesforceSDK/Salesforce.SDK.Tests/Source/Rest/RestRequestTest.cs
+++ b/SalesforceSDK/Salesforce.SDK.Tests/Source/Rest/RestRequestTest.cs
@@ -46,7 +46,7 @@ namespace Salesforce.SDK.Rest
         private const string TEST_QUERY = "testQuery";
         private const string TEST_SEARCH = "testSearch";
         private const string TEST_FIELDS_string = "{\"fieldX\":\"value with spaces\",\"name\":\"testAccount\"}";
-        private const string TEST_FIELDS_LIST_string = "name,fieldX";
+        private const string TEST_FIELDS_LIST_string = "name%2CfieldX";
         private const string FORM_URLENCODED = "application/x-www-form-urlencoded";
         private const string APPLICATION_JSON = "application/json";
         private static readonly HttpMethod PATCH = new HttpMethod("PATCH");


### PR DESCRIPTION
EscapeUriString cannot deal with some special characters correctly, like plus, just leave it there. We should encode it as %2B.  So we should use EscapeDataString to encode every characters like URLEncoder.encode in java. 